### PR TITLE
Scale Type passsed to library by parameter. Improved tare behavior for Felicita Arc (needs the command sent twice)

### DIFF
--- a/AcaiaArduinoBLE.h
+++ b/AcaiaArduinoBLE.h
@@ -34,7 +34,7 @@ enum scale_type{
 class AcaiaArduinoBLE{
     public:
         AcaiaArduinoBLE();
-        bool init(String = "");
+        bool init(String = "", String = "");
         bool tare();
         bool heartbeat();
         float getWeight();
@@ -43,6 +43,7 @@ class AcaiaArduinoBLE{
         bool newWeightAvailable();
     private:
         bool isAcaiaName(String);
+        bool isFelicitaName(String);
         float               _currentWeight;
         BLECharacteristic   _write;
         BLECharacteristic   _read;

--- a/examples/bare_minimum/bare_minimum.ino
+++ b/examples/bare_minimum/bare_minimum.ino
@@ -1,13 +1,18 @@
 #include <AcaiaArduinoBLE.h>
 
+
 AcaiaArduinoBLE acaia;
 void setup() {
   Serial.begin(115200);
   while (!Serial) {}
   Serial.println("Scale Interface test");
-  // Optionally add your Mac Address as an argument: acaia.init("##:##:##:##:##:##");
-  acaia.init();
-  acaia.tare();
+  // Uncomment any of the following lines to connect to your scale, optionally add your Mac Address as an argument:
+
+  //acaia.init("ACAIA","##:##:##:##:##:##");
+  //acaia.init("FELICITA_ARC","##:##:##:##:##:##");
+  acaia.init("FELICITA_ARC");
+  //acaia.init("ACAIA");
+
   acaia.tare();
 }
 

--- a/examples/shotStopper/shotStopper.ino
+++ b/examples/shotStopper/shotStopper.ino
@@ -61,7 +61,13 @@ void setup() {
   pinMode(in, INPUT_PULLUP);
   pinMode(out, OUTPUT);
 
-  acaia.init(); 
+  // Uncomment any of the following lines to connect to your scale, optionally add your Mac Address as an argument:
+
+  //acaia.init("ACAIA","##:##:##:##:##:##");
+  //acaia.init("FELICITA_ARC","##:##:##:##:##:##");
+  acaia.init("FELICITA_ARC");
+  //acaia.init("ACAIA");
+  
 }
 
 void loop() {


### PR DESCRIPTION
Hi Tate
The library can now be called from the arduino sketch directly by uncommenting any of the following:
  //acaia.init("ACAIA","##:##:##:##:##:##");
  //acaia.init("FELICITA_ARC","##:##:##:##:##:##");
  acaia.init("FELICITA_ARC");
  //acaia.init("ACAIA");

so the user does not have to go and change a #define in the cpp file of the library. 
For some reason, the felicita arc likes to be sent its tare command twice(and only one byte), so I added that into the tare function.
I hope that doesn't break any of the Acaia code :)

Best regards,

Pio