### PR TITLE
BooKoo Themis Scale Support

### DIFF
--- a/AcaiaArduinoBLE.cpp
+++ b/AcaiaArduinoBLE.cpp
@@ -17,10 +17,10 @@ byte START_TIMER[7]             = { 0xef, 0xdd, 0x0d, 0x00, 0x00, 0x00, 0x00 };
 byte STOP_TIMER[7]              = { 0xef, 0xdd, 0x0d, 0x00, 0x02, 0x00, 0x02 };
 byte RESET_TIMER[7]             = { 0xef, 0xdd, 0x0d, 0x00, 0x01, 0x00, 0x01 };
 byte TARE_ACAIA[6]              = { 0xef, 0xdd, 0x04, 0x00, 0x00, 0x00 };
-byte TARE_GENERIC[1]            = { 0x54 };
-byte START_TIMER_GENERIC[1]     = { 0x52 };
-byte STOP_TIMER_GENERIC[1]      = { 0x53 };
-byte RESET_TIMER_GENERIC[1]     = { 0x43 };
+byte TARE_GENERIC[6]            = { 0x03, 0x0a, 0x01, 0x00, 0x00, 0x08 };
+byte START_TIMER_GENERIC[6]     = { 0x03, 0x0a, 0x04, 0x00, 0x00, 0x0a };
+byte STOP_TIMER_GENERIC[6]      = { 0x03, 0x0a, 0x05, 0x00, 0x00, 0x0d };
+byte RESET_TIMER_GENERIC[6]     = { 0x03, 0x0a, 0x06, 0x00, 0x00, 0x0c };
 
 /* Generic commands from
    https://github.com/graphefruit/Beanconqueror/blob/master/src/classes/devices/felicita/constants.ts
@@ -222,7 +222,7 @@ bool AcaiaArduinoBLE::newWeightAvailable(){
         if(10 >= l ||                       //10 byte packets for pre-2021 lunar
           (13 >= l && OLD != _type) ||      //13 byte packets for pyxis and older lunar 2021 fw
           (17 == l && NEW == _type) ||      //17 byte packets for newer lunar 2021 fw
-          (18 == l && GENERIC == _type)     //18 byte packets for generic scales
+          (20 == l && GENERIC == _type)     //18 byte packets for generic scales
         ){
             _read.readValue(input, (l > 13) ? 13 : l); // readValue() seems to crash whenever l > weight packet (10, 13 or 18)
 
@@ -256,18 +256,15 @@ bool AcaiaArduinoBLE::newWeightAvailable(){
                             * ((input[7] & 0x02) ? -1 : 1);
             return true;
 
-        }else if( GENERIC == _type && l == 18){
+        }else if( GENERIC == _type && l == 20){
             //Grab weight bytes (3-8),
             // get sign byte (2)
-	        _currentWeight = ( input[2] == 0x2B ? 1  : -1 )
-            *(
-              (input[3] -0x30)*1000 
-            + (input[4] -0x30)*100 
-            + (input[5] -0x30)*10 
-            + (input[6] -0x30)*1 
-            + (input[7] -0x30)*0.1 
-            + (input[8] -0x30)*0.01
-            );
+            _currentWeight = (( input[7] << 16) | (input[8] << 8) | input[9]);
+	        
+	          if (input[6] == 45) { // Check if the value is negative
+            _currentWeight = -_currentWeight;
+                }
+            _currentWeight = _currentWeight / 100;
             return true;
         }
         return false;
@@ -285,7 +282,7 @@ bool AcaiaArduinoBLE::isScaleName(String name){
         || nameShort == "LUNAR"
         || nameShort == "PEARL"
         || nameShort == "PROCH"
-        || nameShort == "FELIC";
+        || nameShort == "BOOKO";
 }
 
 void AcaiaArduinoBLE::exploreService(BLEService service) {

--- a/AcaiaArduinoBLE.cpp
+++ b/AcaiaArduinoBLE.cpp
@@ -147,7 +147,7 @@ bool AcaiaArduinoBLE::init(String mac){
 }
 
 bool AcaiaArduinoBLE::tare(){
-    if(_write.writeValue((_type == GENERIC ? TARE_GENERIC : TARE_ACAIA), 20)){
+    if(_write.writeValue((_type == GENERIC ? TARE_GENERIC : TARE_ACAIA), 6)){
           Serial.println("tare write successful");
           return true;
     }else{
@@ -158,7 +158,7 @@ bool AcaiaArduinoBLE::tare(){
 }
 
 bool AcaiaArduinoBLE::startTimer(){
-    if(_write.writeValue((_type == GENERIC ? START_TIMER_GENERIC : START_TIMER), 7)){
+    if(_write.writeValue((_type == GENERIC ? START_TIMER_GENERIC : START_TIMER), 6)){
 	    Serial.println("start timer write successful");
         return true;
     }else{
@@ -169,7 +169,7 @@ bool AcaiaArduinoBLE::startTimer(){
 }
 
 bool AcaiaArduinoBLE::stopTimer(){
-    if(_write.writeValue((_type == GENERIC ? STOP_TIMER_GENERIC : STOP_TIMER), 7)){
+    if(_write.writeValue((_type == GENERIC ? STOP_TIMER_GENERIC : STOP_TIMER), 6)){
         Serial.println("stop timer write successful");
         return true;
     }else{
@@ -180,7 +180,7 @@ bool AcaiaArduinoBLE::stopTimer(){
 }
 
 bool AcaiaArduinoBLE::resetTimer(){
-    if(_write.writeValue((_type == GENERIC ? RESET_TIMER_GENERIC : RESET_TIMER), 7)){
+    if(_write.writeValue((_type == GENERIC ? RESET_TIMER_GENERIC : RESET_TIMER), 6)){
         Serial.println("reset timer write successful");
         return true;
     }else{

--- a/AcaiaArduinoBLE.h
+++ b/AcaiaArduinoBLE.h
@@ -16,8 +16,8 @@
 #define READ_CHAR_OLD_VERSION  "2a80"
 #define WRITE_CHAR_NEW_VERSION "49535343-8841-43f4-a8d4-ecbe34729bb3"
 #define READ_CHAR_NEW_VERSION  "49535343-1e4d-4bd9-ba61-23c647249616"
-#define WRITE_CHAR_GENERIC     "ffe1"
-#define READ_CHAR_GENERIC      "ffe1"
+#define WRITE_CHAR_GENERIC     "ff11"
+#define READ_CHAR_GENERIC      "ff12"
 #define HEARTBEAT_PERIOD_MS     2750
 
 #include "Arduino.h"

--- a/AcaiaArduinoBLE.h
+++ b/AcaiaArduinoBLE.h
@@ -16,8 +16,8 @@
 #define READ_CHAR_OLD_VERSION  "2a80"
 #define WRITE_CHAR_NEW_VERSION "49535343-8841-43f4-a8d4-ecbe34729bb3"
 #define READ_CHAR_NEW_VERSION  "49535343-1e4d-4bd9-ba61-23c647249616"
-#define WRITE_CHAR_GENERIC     "ff11"
-#define READ_CHAR_GENERIC      "ff12"
+#define WRITE_CHAR_GENERIC     "ff12"
+#define READ_CHAR_GENERIC      "ff11"
 #define HEARTBEAT_PERIOD_MS     2750
 
 #include "Arduino.h"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 Acaia / ~~Felicita~~ Bookoo Scale Gateway using the ArduinoBLE library for devices such as the esp32, arduino nano esp32, and arduino nano iot 33.
 This is an Arduino Library which can be found in the Arduino IDE Library Manager.
 
-# Update to support Bookoo Themis Scale
-I wasn't able to purchase a Acaia Pyxis either new or second hand. Bookoo released a similar bluetooth scale to the Pryxis called the [Bookoo Themis](https://bookoocoffee.com/shop/bookoo-mini-scale/). Support for the Felicita seems to have dropped, so updated the UUID and commands to allow the Bookoo Scale to connect as a generic scale. This has only been tested on a dev board, simulating the button press if was installed on a LM GS3. I want to fully test the code on a production board before submitting a pull request to @tatemazer.
-
 Tested on:
 * MicroControllers:
   * Arduino Nano ESP32

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # AcaiaArduinoBLE
-Acaia / Felicita Scale Gateway using the ArduinoBLE library for devices such as the esp32, arduino nano esp32, and arduino nano iot 33.
+Acaia / ~~Felicita~~ Bookoo Scale Gateway using the ArduinoBLE library for devices such as the esp32, arduino nano esp32, and arduino nano iot 33.
 This is an Arduino Library which can be found in the Arduino IDE Library Manager.
+
+# Update to support Bookoo Themis Scale
+I wasn't able to purchase a Acaia Pyxis either new or second hand. Bookoo released a similar bluetooth scale to the Pryxis called the [Bookoo Themis](https://bookoocoffee.com/shop/bookoo-mini-scale/). Support for the Felicita seems to have dropped and updated the UUID to allow the Bookoo Scale to connect as a generic scale. This has only been tested on a dev board, simulating the button press if was installed on a LM GS3.
 
 Tested on:
 * MicroControllers:
@@ -12,6 +15,7 @@ Tested on:
   *   Acaia Lunar Pre-2021 v2.6.019
   *   Acaia Lunar 2021 v1.0.016*
   *   Acaia Pearl S 1.0.056
+  *   Bookoo Themis
 * Espresso Machines:
   * La Marzocco Linea Mini
   * Linea Micra

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Acaia / ~~Felicita~~ Bookoo Scale Gateway using the ArduinoBLE library for devic
 This is an Arduino Library which can be found in the Arduino IDE Library Manager.
 
 # Update to support Bookoo Themis Scale
-I wasn't able to purchase a Acaia Pyxis either new or second hand. Bookoo released a similar bluetooth scale to the Pryxis called the [Bookoo Themis](https://bookoocoffee.com/shop/bookoo-mini-scale/). Support for the Felicita seems to have dropped and updated the UUID to allow the Bookoo Scale to connect as a generic scale. This has only been tested on a dev board, simulating the button press if was installed on a LM GS3.
+I wasn't able to purchase a Acaia Pyxis either new or second hand. Bookoo released a similar bluetooth scale to the Pryxis called the [Bookoo Themis](https://bookoocoffee.com/shop/bookoo-mini-scale/). Support for the Felicita seems to have dropped, so updated the UUID and commands to allow the Bookoo Scale to connect as a generic scale. This has only been tested on a dev board, simulating the button press if was installed on a LM GS3. I want to fully test the code on a production board before submitting a pull request to @tatemazer.
 
 Tested on:
 * MicroControllers:

--- a/examples/shotStopper/shotStopper.ino
+++ b/examples/shotStopper/shotStopper.ino
@@ -114,8 +114,8 @@ struct Shot {
 Shot shot = {0,0,0,0,{},{},0,false,ENDTYPE::UNDEF};
 
 //BLE peripheral device
-BLEService weightService("00002a98-0000-1000-8000-00805f9b34fb"); // create service
-BLEByteCharacteristic weightCharacteristic("0x2A98",  BLEWrite | BLERead);
+BLEService weightService("0x0FFE"); // create service
+BLEByteCharacteristic weightCharacteristic("0xFF11",  BLEWrite | BLERead);
 
 void setup() {
   setCpuFrequencyMhz(80);

--- a/examples/shotStopper/shotStopper.ino
+++ b/examples/shotStopper/shotStopper.ino
@@ -351,6 +351,7 @@ void setBrewingState(bool brewing){
     shot.start_timestamp_s = seconds_f();
     shot.shotTimer = 0;
     shot.datapoints = 0;
+    scale.resetTimer();
     scale.startTimer();
     if(AUTOTARE){
       scale.tare();


### PR DESCRIPTION
# Update to support Bookoo Themis Scale
I wasn't able to purchase a Acaia Pyxis either new or second hand. Bookoo released a similar bluetooth scale to the Pryxis called the [Bookoo Themis](https://bookoocoffee.com/shop/bookoo-mini-scale/). Support for the Felicita seems to have dropped, so updated the UUID and commands to allow the Bookoo Scale to connect as a generic scale. This has only been tested on a dev board, simulating the button press if was installed on a LM GS3. I want to fully test the code on a production board before submitting a pull request to @tatemazer.

Code has been tested on a production board. Pull request raised to bring into base. 