### PR TITLE
Bug fix: stop brewing if disconnected

### DIFF
--- a/examples/shotStopper/shotStopper.ino
+++ b/examples/shotStopper/shotStopper.ino
@@ -71,7 +71,7 @@
 
 #define BUTTON_STATE_ARRAY_LENGTH 31
 
-typedef enum {BUTTON, WEIGHT, TIME, UNDEF} ENDTYPE;
+typedef enum {BUTTON, WEIGHT, TIME, DISCONNECT, UNDEF} ENDTYPE;
 
 // RGB Colors {Red,Green,Blue}
 int RED[3] = {255, 0, 0};
@@ -172,6 +172,8 @@ void loop() {
     scale.init(); 
     currentWeight = 0;
     if(shot.brewing){
+      shot.brewing = false;
+      shot.end = ENDTYPE::DISCONNECT;
       setBrewingState(false);
     }
     if(scale.isConnected()){
@@ -361,17 +363,20 @@ void setBrewingState(bool brewing){
     Serial.print("ShotEnded by ");
     switch (shot.end) {
       case ENDTYPE::TIME:
-      Serial.println("time");
-      break;
-    case ENDTYPE::WEIGHT:
-    Serial.println("weight");
-      break;
-    case ENDTYPE::BUTTON:
-    Serial.println("button");
-      break;
-    case ENDTYPE::UNDEF:
-      Serial.println("undef");
-      break;
+        Serial.println("time");
+        break;
+      case ENDTYPE::WEIGHT:
+        Serial.println("weight");
+        break;
+      case ENDTYPE::BUTTON:
+        Serial.println("button");
+        break;
+      case ENDTYPE::DISCONNECT:
+        Serial.println("disconnect");
+        break;
+      case ENDTYPE::UNDEF:
+        Serial.println("undef");
+        break;
     }
 
     shot.end_s = seconds_f() - shot.start_timestamp_s;


### PR DESCRIPTION
  resolves out-of-sync issues primarily
  seen on GS3. if the shotStopper is not
  connected to the scale, be sure that the
  shot status is not-brewing, even if it is
  currently physically brewing.

  This will not physically end brewing on a
  button-based machine, but will end brewing
  on lever style machines