### PR TITLE
Added 13 byte data with OLD read/write char to suit original pearl

### DIFF
--- a/AcaiaArduinoBLE.cpp
+++ b/AcaiaArduinoBLE.cpp
@@ -235,6 +235,7 @@ bool AcaiaArduinoBLE::newWeightAvailable(){
 
         // Get packet
         if(10 >= l ||                       //10 byte packets for pre-2021 lunar
+          (13 == l && OLD == _type) ||      //13 byte packets for original pearl AP001
           (13 >= l && OLD != _type) ||      //13 byte packets for pyxis and older lunar 2021 fw
           (14 == l && OLD == _type) ||      //14 byte packets for lunar 2021 AL008
           (17 == l && NEW == _type) ||      //17 byte packets for newer lunar 2021 fw
@@ -252,7 +253,7 @@ bool AcaiaArduinoBLE::newWeightAvailable(){
         }
 
         // Parse New style data packet
-        if (NEW == _type && (13 == l || 17 == l) && input[4] == 0x05)
+        if (((NEW == _type && (13 == l || 17 == l)) || (OLD == _type && 13 == l)) && input[4] == 0x05)
         {
             //Grab weight bytes (5 and 6) 
             // apply scaling based on the unit byte (9)


### PR DESCRIPTION
Added 13 byte data stream for use with original pearl scales. It follows the same data format as some of the lunar versions.

The original code would let me tare but would not read weight data. With this change it sends positive and negative values scaled correctly.

Some debug data

Found device 'PROCHBT001' 1820
Connecting ...
Connected
Discovering attributes ...
Attributes discovered

Device name: PROCHBT001
Appearance: 0x0

Service 1800
        Characteristic 2a00, properties 0x2, value 0x50524F43484254303031
                Descriptor 2803, value 0x020500012A
                Descriptor 2a01, value 0x0002
        Characteristic 2a01, properties 0x2, value 0x0002
                Descriptor 2803, value 0x020700042A
                Descriptor 2a04, value 0x010001006400E204
        Characteristic 2a04, properties 0x2, value 0x010001006400E204
                Descriptor 2803, value 0x040900992A
                Descriptor 2a99, value 0x
        Characteristic 2a99, properties 0x4
Service 1801
Service 1820
        Characteristic 2a80, properties 0x14
                Descriptor 2902, value 0x0000
Service 180f
        Characteristic 2a19, properties 0x12, value 0x64
                Descriptor 2902, value 0x0000
Service 180a
        Characteristic 2a25, properties 0x2, value 0x303030
                Descriptor 2803, value 0x021700272A
                Descriptor 2a27, value 0x4254412D43313031302D32
        Characteristic 2a27, properties 0x2, value 0x4254412D43313031302D32
                Descriptor 2803, value 0x021900262A
                Descriptor 2a26, value 0x53444B20322E30
        Characteristic 2a26, properties 0x2, value 0x53444B20322E30
                Descriptor 2803, value 0x021B00282A
                Descriptor 2a28, value 0x462D536E6F775265782D5350532D76303034
        Characteristic 2a28, properties 0x2, value 0x462D536E6F775265782D5350532D76303034
                Descriptor 2803, value 0x021D00292A
                Descriptor 2a29, value 0x456E7A7974656B
        Characteristic 2a29, properties 0x2, value 0x456E7A7974656B
                Descriptor 2803, value 0x021F00502A
                Descriptor 2a50, value 0x303031433937
        Characteristic 2a50, properties 0x2, value 0x303031433937
Old version Acaia Detected
subscribed!
identify write successful
notification request write successful
tare write successful
tare write successful


And some data that gets sent
0.00g 13: 0xEFDD0C08050000000001010906
250.40g 13: 0xEFDD0C0805700900000101790F
147.30g 13: 0xEFDD0C0805C10500000100CA0A
