### PR TITLE
Add AtomHeart Eclair scale support

### DIFF
--- a/AcaiaArduinoBLE.cpp
+++ b/AcaiaArduinoBLE.cpp
@@ -30,10 +30,31 @@ byte START_TIMER_FELICITA[1]        = { 0x52 }; // 'Start_Timer'
 byte STOP_TIMER_FELICITA[1]         = { 0x53 }; // 'Stop_Timer'
 byte RESET_TIMER_FELICITA[1]        = { 0x43 }; // 'Reset_Timer'
 byte WEIGHT_TIMER_MODE_FELICITA[1]  = { 0x32 }; // 'Weight+timer mode (known-good wake state)
+byte TARE_ECLAIR[3]                 = { 0x54, 0x01, 0x01 };
+byte START_TIMER_ECLAIR[3]          = { 0x53, 0x01, 0x01 };
+byte STOP_TIMER_ECLAIR[3]           = { 0x45, 0x01, 0x01 };
+byte RESET_TIMER_ECLAIR[3]          = { 0x52, 0x01, 0x01 };
 
 /* Generic commands from
    https://github.com/graphefruit/Beanconqueror/blob/master/src/classes/devices/felicita/constants.ts
 */
+
+uint8_t calculateXOR(const byte data[], int length){
+    uint8_t result = 0;
+    for(int i = 0; i < length; i++){
+        result ^= data[i];
+    }
+    return result;
+}
+
+int32_t readInt32LittleEndian(const byte data[]){
+    return (int32_t)(
+        ((uint32_t)data[0]) |
+        ((uint32_t)data[1] << 8) |
+        ((uint32_t)data[2] << 16) |
+        ((uint32_t)data[3] << 24)
+    );
+}
 
 AcaiaArduinoBLE::AcaiaArduinoBLE(bool debug){
     _debug = debug;
@@ -130,6 +151,11 @@ bool AcaiaArduinoBLE::init(String mac){
                 _type   = FELICITA;
                 _write  = peripheral.characteristic(WRITE_CHAR_FELICITA);
                 _read   = peripheral.characteristic(READ_CHAR_FELICITA);
+            } else if(peripheral.characteristic(READ_CHAR_ECLAIR).canSubscribe()){
+                Serial.println("Eclair Scale Detected");
+                _type   = ECLAIR;
+                _write  = peripheral.characteristic(WRITE_CHAR_ECLAIR);
+                _read   = peripheral.characteristic(READ_CHAR_ECLAIR);
             }
             else{
                 Serial.println("unable to determine scale type");
@@ -188,6 +214,7 @@ bool AcaiaArduinoBLE::tare(){
     switch(_type){
         case GENERIC:  ok = _write.writeValue(TARE_GENERIC,  sizeof(TARE_GENERIC));  break;
         case FELICITA: ok = _write.writeValue(TARE_FELICITA, sizeof(TARE_FELICITA)); break;
+        case ECLAIR:   ok = _write.writeValue(TARE_ECLAIR,   sizeof(TARE_ECLAIR));   break;
         default:       ok = _write.writeValue(TARE_ACAIA,    sizeof(TARE_ACAIA));    break;
     }
     if(ok){
@@ -205,6 +232,7 @@ bool AcaiaArduinoBLE::startTimer(){
     switch(_type){
         case GENERIC:  ok = _write.writeValue(START_TIMER_GENERIC,  sizeof(START_TIMER_GENERIC));  break;
         case FELICITA: ok = _write.writeValue(START_TIMER_FELICITA, sizeof(START_TIMER_FELICITA)); break;
+        case ECLAIR:   ok = _write.writeValue(START_TIMER_ECLAIR,   sizeof(START_TIMER_ECLAIR));   break;
         default:       ok = _write.writeValue(START_TIMER,          sizeof(START_TIMER));          break;
     }
     if(ok){
@@ -222,6 +250,7 @@ bool AcaiaArduinoBLE::stopTimer(){
     switch(_type){
         case GENERIC:  ok = _write.writeValue(STOP_TIMER_GENERIC,  sizeof(STOP_TIMER_GENERIC));  break;
         case FELICITA: ok = _write.writeValue(STOP_TIMER_FELICITA, sizeof(STOP_TIMER_FELICITA)); break;
+        case ECLAIR:   ok = _write.writeValue(STOP_TIMER_ECLAIR,   sizeof(STOP_TIMER_ECLAIR));   break;
         default:       ok = _write.writeValue(STOP_TIMER,          sizeof(STOP_TIMER));          break;
     }
     if(ok){
@@ -239,6 +268,7 @@ bool AcaiaArduinoBLE::resetTimer(){
     switch(_type){
         case GENERIC:  ok = _write.writeValue(RESET_TIMER_GENERIC,  sizeof(RESET_TIMER_GENERIC));  break;
         case FELICITA: ok = _write.writeValue(RESET_TIMER_FELICITA, sizeof(RESET_TIMER_FELICITA)); break;
+        case ECLAIR:   ok = _write.writeValue(RESET_TIMER_ECLAIR,   sizeof(RESET_TIMER_ECLAIR));   break;
         default:       ok = _write.writeValue(RESET_TIMER,          sizeof(RESET_TIMER));          break;
     }
     if(ok){
@@ -252,7 +282,13 @@ bool AcaiaArduinoBLE::resetTimer(){
 }
 
 bool AcaiaArduinoBLE::tareStartTimer(){
-    if(_write.writeValue(TARE_START_TIMER_BOOKOO, 6)){
+    bool ok;
+    if(_type == ECLAIR){
+        ok = _write.writeValue(START_TIMER_ECLAIR, sizeof(START_TIMER_ECLAIR));
+    }else{
+        ok = _write.writeValue(TARE_START_TIMER_BOOKOO, sizeof(TARE_START_TIMER_BOOKOO));
+    }
+    if(ok){
           Serial.println("tare and start timer write successful");
           return true;
     }else{
@@ -263,9 +299,13 @@ bool AcaiaArduinoBLE::tareStartTimer(){
 }
 
 bool AcaiaArduinoBLE::beep(){
-
-    // for acaia's, use the tare command to generate the beep
-    if(_write.writeValue((_type == GENERIC ? BEEP_LEVEL_1_BOOKOO : TARE_ACAIA), 6)){
+    bool ok;
+    switch(_type){
+        case GENERIC: ok = _write.writeValue(BEEP_LEVEL_1_BOOKOO, sizeof(BEEP_LEVEL_1_BOOKOO)); break;
+        case ECLAIR:  ok = _write.writeValue(TARE_ECLAIR,         sizeof(TARE_ECLAIR));         break;
+        default:      ok = _write.writeValue(TARE_ACAIA,          sizeof(TARE_ACAIA));          break;
+    }
+    if(ok){
           Serial.println("beep write successful");
           return true;
     }else{
@@ -276,6 +316,10 @@ bool AcaiaArduinoBLE::beep(){
 }
 
 bool AcaiaArduinoBLE::heartbeat(){
+    if(_type == ECLAIR){
+        return true;
+    }
+
     if(_write.writeValue(HEARTBEAT, 7)){
         _lastHeartBeat = millis();
         return true;
@@ -313,7 +357,7 @@ bool AcaiaArduinoBLE::newWeightAvailable(){
         int l = _read.valueLength();
 
         // Get packet
-        if(10 >= l ||                       //10 byte packets for pre-2021 lunar
+        if(10 >= l ||                       //10 byte packets for pre-2021 lunar and Eclair
           (13 >= l && OLD != _type) ||      //13 byte packets for pyxis and older lunar 2021 fw
           (14 == l && OLD == _type) ||      //14 byte packets for lunar 2021 AL008
           (17 == l && NEW == _type) ||      //17 byte packets for newer lunar 2021 fw
@@ -375,6 +419,14 @@ bool AcaiaArduinoBLE::newWeightAvailable(){
                   + (input[7] - 0x30) * 0.1
                   + (input[8] - 0x30) * 0.01 );
             newWeightPacket = true;
+
+        }else if( ECLAIR == _type && l == 10 && input[0] == 'W'){
+            if(calculateXOR(input + 1, 8) == input[9]){
+                _currentWeight = readInt32LittleEndian(input + 1) / 1000.0;
+                newWeightPacket = true;
+            }else if(_debug){
+                Serial.println("Eclair packet XOR failed");
+            }
         }
         if(newWeightPacket){
             if(_lastPacket){
@@ -398,7 +450,8 @@ bool AcaiaArduinoBLE::isScaleName(String name){
         || nameShort == "PEARL"
         || nameShort == "PROCH"
         || nameShort == "BOOKO"
-        || nameShort == "FELIC";
+        || nameShort == "FELIC"
+        || nameShort == "ECLAI";
 }
 
 void AcaiaArduinoBLE::exploreService(BLEService service) {

--- a/AcaiaArduinoBLE.h
+++ b/AcaiaArduinoBLE.h
@@ -13,7 +13,7 @@
 #ifndef AcaiaArduinoBLE_h
 #define AcaiaArduinoBLE_h
 
-#define LIBRARY_VERSION        "3.3.0"
+#define LIBRARY_VERSION        "3.4.0"
 #define WRITE_CHAR_OLD_VERSION "2a80"
 #define READ_CHAR_OLD_VERSION  "2a80"
 #define WRITE_CHAR_NEW_VERSION "49535343-8841-43f4-a8d4-ecbe34729bb3"
@@ -22,6 +22,8 @@
 #define READ_CHAR_GENERIC      "ff11"
 #define WRITE_CHAR_FELICITA    "ffe1"   // Felicita Arc: single ffe1 char (service ffe0) for both
 #define READ_CHAR_FELICITA     "ffe1"   //   notify (weight) and write (commands)
+#define WRITE_CHAR_ECLAIR      "4F9A45BA-8E1B-4E07-E157-0814D393B968"
+#define READ_CHAR_ECLAIR       "AD736C5F-BBC9-1F96-D304-CB5D5F41E160"
 #define HEARTBEAT_PERIOD_MS     2750
 #define MAX_PACKET_PERIOD_MS    5000
 
@@ -32,7 +34,8 @@ enum scale_type{
     OLD,     // Lunar (pre-2021)
     NEW,     // Lunar (2021), Pyxis
     GENERIC, // BooKoo Themis, Decent, etc (ff11/ff12, binary protocol)
-    FELICITA // Felicita Arc (ffe1, single-byte ASCII protocol)
+    FELICITA, // Felicita Arc (ffe1, single-byte ASCII protocol)
+    ECLAIR   // AtomHeart Eclair (custom service/characteristics)
 };
 
 class AcaiaArduinoBLE{

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AcaiaArduinoBLE
-Acaia / Bookoo / Felicita Scale Gateway using the ArduinoBLE library for esp32-based devices.
+Acaia / Bookoo / Felicita / AtomHeart Eclair Scale Gateway using the ArduinoBLE library for esp32-based devices.
 This is an Arduino Library which can be found in the Arduino IDE Library Manager.
 
 ## Scale Compatibility
@@ -11,9 +11,10 @@ This is an Arduino Library which can be found in the Arduino IDE Library Manager
 | Acaia  | Pearl S | USB-Micro                  | v1.0.056 | Ok    | Yes | Yes | Yes
 | Acaia  | Pearl S | USB-C                      | ----     | Ok    | Yes | Yes  | Yes
 | Acaia  | Pyxis   | ----                       | v1.0.022 | Good  | Not Recommended (too sensitive) | Yes | Yes
-| Bookoo | Themis  Mini | ----                       | v1.0.5   | Great | Yes | Yes | Yes 
-| Bookoo | Themis Ultra  | ----                 | ----   | Great | Yes | Yes | Yes 
-| Felicita | Arc   | ----                       | ----   | ---- | Yes | Yes | Yes 
+| Bookoo | Themis  Mini | ----                       | v1.0.5   | Great | Yes | Yes | Yes
+| Bookoo | Themis Ultra  | ----                 | ----   | Great | Yes | Yes | Yes
+| Felicita | Arc   | ----                       | ----   | ---- | Yes | Yes | Yes
+| AtomHeart | Eclair | ----                    | v2.1.0 | Testing | Yes | Yes | Yes
 
 
 ## Requirements
@@ -85,6 +86,8 @@ You can find a demo on Youtube:
 
 ☑ Bookoo
 
+☑ AtomHeart Eclair
+
 
 ## Bugs/Missing
 1. Tare command is less reliable than pressing the tare button for pyxis
@@ -98,6 +101,8 @@ In addition to some minor notes from [pyacaia](https://github.com/lucapinello/py
 Felicita Arc support contributions from baettigp and A-TWJ
 
 Bookoo contributions from philgood and same31
+
+AtomHeart Eclair contributions from AtomHeart-Lang
 
 lunar 2019 contributions from jniebuhr
 

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=AcaiaArduinoBLE
-version=3.3.0
+version=3.4.0
 author=Tate Mazer <mazertate@gmail.com>
 maintainer=Tate Mazer <mazertate@gmail.com>
-sentence=A library that connects BLE devices to Acaia Scales.
+sentence=A library that connects BLE devices to Acaia, Bookoo, Felicita, and AtomHeart Eclair scales.
 paragraph=Uses the ArduinoBLE library and should support any BLE module.
 category=Device Control
 url=https://github.com/tatemazer/AcaiaArduinoBLE


### PR DESCRIPTION
Hi,

This PR adds support for the **AtomHeart Eclair** Bluetooth scale.

AtomHeart is a one-person studio I founded in 2022, focused on smart coffee hardware. Eclair launched in China in 2024 and already integrates with Bluetooth-enabled coffee systems including Gaggiuino and Decent. We plan to bring it to more markets, and would be glad to make it available to the shotStopper community as well.

## Changes

- Add the `ECLAIR` scale type and its BLE characteristic UUIDs.
- Detect Eclair scales by the existing five-character name-prefix mechanism (`ECLAI`) and confirm them through characteristic discovery.
- Parse Eclair 10-byte weight notifications (`W`, signed little-endian int32 milligrams, timer, payload XOR).
- Implement Eclair-specific tare, reset timer, start timer, and stop timer commands.
- Map `tareStartTimer()` to Eclair's combined tare/reset/start command.
- Skip identify, notification-request, and heartbeat packets that are not part of the Eclair protocol.
- Document AtomHeart Eclair compatibility and the required firmware version (`v2.1.0+`).

## Compatibility with current main

This branch is rebased onto the latest `main`, including the recent non-blocking command-write changes. Existing Acaia, Bookoo/generic, and Felicita paths keep their upstream non-blocking writes unchanged. Eclair alone uses write-with-response because its command characteristic advertises `WRITE`, not `WRITE_NR`.

The library version remains unchanged at `3.3.0`, leaving release versioning to the maintainer.

## Testing

Verified on an ESP32-S3 Dev Module with Arduino ESP32 Core 3.3.3 and an Eclair running firmware v2.1.x:

- BLE discovery, connection, characteristic discovery, subscription, and continuous weight updates
- Tare
- Timer reset, start, and stop
- Tare while the timer is running, confirming that the timer continues
- Full shotStopper call chain: `resetTimer() -> startTimer() -> tare() -> weight monitoring -> stopTimer()`
- BLE connection stability throughout both test sequences
- Final branch compiled successfully from the committed state

Happy to answer questions or adjust the implementation to match the project's preferred conventions.

<img width="1200" height="1941" alt="AtomHeart Eclair overview" src="https://github.com/user-attachments/assets/a9ec42fe-8d17-4ef0-959c-9ba183b8d03b" />
<img width="1200" height="2067" alt="AtomHeart Eclair details" src="https://github.com/user-attachments/assets/74a71b6c-bd46-465f-b388-6beff72055ec" />
